### PR TITLE
feat: implement basic Open, Read, and ReadDirAll

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,10 @@ main
 *.exe
 *.test
 
+# Mountpoints
+mnt/
+test/
+
 **/.DS_Store
 
 go.work

--- a/fs/dir.go
+++ b/fs/dir.go
@@ -15,6 +15,11 @@ func (Dir) Lookup(ctx context.Context, name string) (fs.Node, error) {
 	if debug {
 		log.Printf("Lookup called for: %s", name)
 	}
+
+	if name == "hello.txt" {
+		return &File{}, nil
+	}
+
 	return nil, syscall.ENOENT
 }
 

--- a/fs/dir.go
+++ b/fs/dir.go
@@ -11,21 +11,43 @@ import (
 
 var debug = true
 
-func (Dir) Lookup(ctx context.Context, name string) (fs.Node, error) {
+func (d *Dir) Lookup(ctx context.Context, name string) (fs.Node, error) {
 	if debug {
 		log.Printf("Lookup called for: %s", name)
 	}
 
-	if name == "hello.txt" {
-		return &File{}, nil
+	node, exists := d.Nodes[name]
+	if !exists {
+		return nil, syscall.ENOENT
 	}
 
-	return nil, syscall.ENOENT
+	return node, nil
 }
 
-func (Dir) ReadDirAll(ctx context.Context) ([]fuse.Dirent, error) {
+func (d *Dir) ReadDirAll(ctx context.Context) ([]fuse.Dirent, error) {
 	if debug {
 		log.Println("ReadDirAll() called")
 	}
-	return []fuse.Dirent{}, nil
+
+	var entries []fuse.Dirent
+
+	// Get all nodes (files/dirs) inside the mountpoint and append to dirents list
+	// Not really useful rn because only 1 hardcoded, read-only file
+	for name, node := range d.Nodes {
+		direntType := fuse.DT_Unknown
+
+		switch node.(type) {
+		case *File:
+			direntType = fuse.DT_File
+		case *Dir:
+			direntType = fuse.DT_Dir
+		}
+
+		entries = append(entries, fuse.Dirent{
+			Name: name,
+			Type: direntType,
+		})
+	}
+
+	return entries, nil
 }

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -11,13 +11,20 @@ import (
 type FS struct{}
 
 func (FS) Root() (fs.Node, error) {
-	return Dir{}, nil
+	return &Dir{
+		Nodes: map[string]fs.Node{
+			"hello.txt": &File{}, // Hardcoded default file
+		},
+	}, nil
 }
 
-type Dir struct{}
+type Dir struct {
+	Nodes map[string]fs.Node
+}
 
 func (Dir) Attr(ctx context.Context, a *fuse.Attr) error {
 	a.Inode = 1                 //inode 1 cuz root
 	a.Mode = os.ModeDir | 0o755 //octal perms for rwx r-x r-x
+
 	return nil
 }

--- a/fs/open_and_read.go
+++ b/fs/open_and_read.go
@@ -1,0 +1,47 @@
+package fs
+
+import (
+	"context"
+	"syscall"
+
+	"bazil.org/fuse"
+)
+
+// File struct
+type File struct{}
+
+// File attributes
+func (File) Attr(ctx context.Context, a *fuse.Attr) error {
+	a.Inode = 2
+	a.Mode = 0o444 // read-only
+	a.Size = uint64(len("Hello from radFS!\n"))
+	return nil
+}
+
+func (File) Open(ctx context.Context, req *fuse.OpenRequest, resp *fuse.OpenResponse) error {
+	// If opened in write mode → deny
+	if req.Flags.IsWriteOnly() || req.Flags.IsReadWrite() {
+		return fuse.Errno(syscall.EACCES)
+	}
+
+	return nil
+}
+
+func (f *File) Read(ctx context.Context, req *fuse.ReadRequest, resp *fuse.ReadResponse) error {
+
+	content := []byte("Hello from radFS!\n")
+
+	// If offset is beyond file size → EOF
+	if req.Offset >= int64(len(content)) {
+		resp.Data = []byte{}
+		return nil
+	}
+
+	// Calculate how much we can safely read
+	end := req.Offset + int64(req.Size)
+	end = min(end, int64(len(content)))
+
+	resp.Data = content[req.Offset:end]
+
+	return nil
+}


### PR DESCRIPTION
## Context
Basic working PoC to  understand how FUSE filesystems work before building the dynamic radix tree architecture.

## Description
Implemented a hardcoded, read-only hello.txt filee. OS can successfully mount, discover, and read from the filesystem.

### Changes
 - `/fs/open_and_read.go`: Added File struct with Attr (read-only perms), Open (blocks write access), and Read (returns content safely).
 -  `/fs/dir.go`: Updated Lookup to resolve "hello.txt". Updated ReadDirAll to return non empty fuse.Dirent so `ls` correctly displays the file.

### Tests
 - `go run cmd/radFS/main.go mnt/`: Successfully mounts
 - `ls -la mnt/`: Sucessfully shows `hello.txt`
 - `cat mnt/hello.txt`: Successfully prints the contents of `hello.txt`
 - `echo "test" > mnt/hello.txt`: Fails with Permission Denied as expected

## Docs
Added baseline FUSE file reading and directory listing implementations.
