### PR TITLE
feat: add dynamic time attr modification

### DIFF
--- a/cmd/radFS/main.go
+++ b/cmd/radFS/main.go
@@ -54,7 +54,7 @@ func main() {
 	signal.Notify(signals, os.Interrupt)
 
 	<-signals
-	log.Println("Interrupt received: shutting down.")
+	log.Println(" Interrupt received: shutting down.")
 	unmount_err := fuse.Unmount(cfg.mount)
 
 	if unmount_err != nil {

--- a/internal/fs/dir.go
+++ b/internal/fs/dir.go
@@ -38,6 +38,7 @@ func (d *Dir) Setattr(ctx context.Context, req *fuse.SetattrRequest, resp *fuse.
 	if req.Valid.Mtime() {
 		d.mtime = req.Mtime
 	}
+	d.ctime = time.Now()
 
 	resp.Attr.Inode = d.inode
 	resp.Attr.Mode = os.ModeDir | 0o755

--- a/internal/fs/dir.go
+++ b/internal/fs/dir.go
@@ -28,18 +28,15 @@ func (d *Dir) Attr(ctx context.Context, a *fuse.Attr) error {
 	return nil
 }
 
-func (d *Dir) Setattr(ctx context,Context, req *fuse.SetattrRequest, resp *fuse.SetattrResponse) error {
-	f.mu.Lock()
+func (d *Dir) Setattr(ctx context.Context, req *fuse.SetattrRequest, resp *fuse.SetattrResponse) error {
+	d.mu.Lock()
 	defer d.mu.Unlock()
 
 	if req.Valid.Atime() {
 		d.atime = req.Atime
 	}
-	if req.Valid.A=Mtime() {
+	if req.Valid.Mtime() {
 		d.mtime = req.Mtime
-	}
-	if req.Valid.Ctime() {
-		d.ctime = req.Ctime
 	}
 
 	resp.Attr.Inode = d.inode
@@ -47,7 +44,7 @@ func (d *Dir) Setattr(ctx context,Context, req *fuse.SetattrRequest, resp *fuse.
 
 	resp.Attr.Atime = d.atime
 	resp.Attr.Mtime = d.mtime
-	resp.Attr.Ctime = d.Ctime
+	resp.Attr.Ctime = d.ctime
 
 	return nil
 
@@ -115,10 +112,10 @@ func (d *Dir) Mkdir(ctx context.Context, req *fuse.MkdirRequest) (fs.Node, error
 	newDir := &Dir{
 		inode: nextInode(),
 		Nodes: make(map[string]fs.Node),
-		fs: d.fs,
-		atime = time.Now(),
-		ctime = time.Now(),
-		mtime = time.Now()
+		fs:    d.fs,
+		atime: time.Now(),
+		ctime: time.Now(),
+		mtime: time.Now(),
 	}
 	d.Nodes[req.Name] = newDir
 
@@ -144,11 +141,15 @@ func (d *Dir) Create(ctx context.Context, req *fuse.CreateRequest, resp *fuse.Cr
 
 	f := &File{
 		inode: nextInode(),
-		data: []byte{},
-		mode: uint32(req.Mode),
+		data:  []byte{},
+		mode:  uint32(req.Mode),
 		atime: time.Now(),
 		ctime: time.Now(),
 		mtime: time.Now(),
+	}
+
+	if _, exists := d.Nodes[req.Name]; exists { // checking for dupes
+		return nil, nil, syscall.EEXIST
 	}
 	d.Nodes[req.Name] = f
 
@@ -180,7 +181,6 @@ func (d *Dir) Remove(ctx context.Context, req *fuse.RemoveRequest) error {
 			return syscall.ENOTEMPTY
 		}
 	}
-	
 
 	delete(d.Nodes, req.Name)
 

--- a/internal/fs/dir.go
+++ b/internal/fs/dir.go
@@ -21,8 +21,36 @@ func (f *FS) DebugPrint(msg string, v ...any) {
 func (d *Dir) Attr(ctx context.Context, a *fuse.Attr) error {
 	a.Inode = d.inode
 	a.Mode = os.ModeDir | 0o755
+	a.Atime = d.atime
+	a.Mtime = d.mtime
+	a.Ctime = d.ctime
 
 	return nil
+}
+
+func (d *Dir) Setattr(ctx context,Context, req *fuse.SetattrRequest, resp *fuse.SetattrResponse) error {
+	f.mu.Lock()
+	defer d.mu.Unlock()
+
+	if req.Valid.Atime() {
+		d.atime = req.Atime
+	}
+	if req.Valid.A=Mtime() {
+		d.mtime = req.Mtime
+	}
+	if req.Valid.Ctime() {
+		d.ctime = req.Ctime
+	}
+
+	resp.Attr.Inode = d.inode
+	resp.Attr.Mode = os.ModeDir | 0o755
+
+	resp.Attr.Atime = d.atime
+	resp.Attr.Mtime = d.mtime
+	resp.Attr.Ctime = d.Ctime
+
+	return nil
+
 }
 
 func (d *Dir) Lookup(ctx context.Context, name string) (fs.Node, error) {
@@ -36,6 +64,8 @@ func (d *Dir) Lookup(ctx context.Context, name string) (fs.Node, error) {
 	if !ok {
 		return nil, syscall.ENOENT
 	}
+
+	d.atime = time.Now()
 
 	return node, nil
 }
@@ -60,6 +90,8 @@ func (d *Dir) ReadDirAll(ctx context.Context) ([]fuse.Dirent, error) {
 		entries = append(entries, fuse.Dirent{Name: name, Type: dt})
 	}
 
+	d.atime = time.Now()
+
 	return entries, nil
 }
 
@@ -80,8 +112,18 @@ func (d *Dir) Mkdir(ctx context.Context, req *fuse.MkdirRequest) (fs.Node, error
 		return nil, syscall.EEXIST
 	}
 
-	newDir := &Dir{inode: nextInode(), Nodes: make(map[string]fs.Node), fs: d.fs}
+	newDir := &Dir{
+		inode: nextInode(),
+		Nodes: make(map[string]fs.Node),
+		fs: d.fs,
+		atime = time.Now(),
+		ctime = time.Now(),
+		mtime = time.Now()
+	}
 	d.Nodes[req.Name] = newDir
+
+	d.mtime = time.Now()
+	d.ctime = time.Now()
 
 	return newDir, nil
 }
@@ -109,6 +151,9 @@ func (d *Dir) Create(ctx context.Context, req *fuse.CreateRequest, resp *fuse.Cr
 		mtime: time.Now(),
 	}
 	d.Nodes[req.Name] = f
+
+	d.mtime = time.Now()
+	d.ctime = time.Now()
 
 	return f, f, nil
 }
@@ -138,6 +183,9 @@ func (d *Dir) Remove(ctx context.Context, req *fuse.RemoveRequest) error {
 	
 
 	delete(d.Nodes, req.Name)
+
+	d.mtime = time.Now()
+	d.ctime = time.Now()
 
 	return nil
 }

--- a/internal/fs/dir.go
+++ b/internal/fs/dir.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"os"
 	"syscall"
+	"time"
 
 	"bazil.org/fuse"
 	"bazil.org/fuse/fs"
@@ -99,7 +100,14 @@ func (d *Dir) Create(ctx context.Context, req *fuse.CreateRequest, resp *fuse.Cr
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
-	f := &File{inode: nextInode(), data: []byte{}, mode: uint32(req.Mode)}
+	f := &File{
+		inode: nextInode(),
+		data: []byte{},
+		mode: uint32(req.Mode),
+		atime: time.Now(),
+		ctime: time.Now(),
+		mtime: time.Now(),
+	}
 	d.Nodes[req.Name] = f
 
 	return f, f, nil

--- a/internal/fs/file.go
+++ b/internal/fs/file.go
@@ -3,6 +3,7 @@ package fs
 import (
 	"context"
 	"os"
+	"time"
 
 	"bazil.org/fuse"
 	"bazil.org/fuse/fs"
@@ -14,6 +15,9 @@ func (f *File) Attr(ctx context.Context, a *fuse.Attr) error {
 	a.Inode = f.inode
 	a.Mode = os.FileMode(f.mode)
 	a.Size = uint64(len(f.data))
+	a.Atime = f.atime
+	a.Mtime = f.mtime
+	a.Ctime = f.ctime
 
 	return nil
 }
@@ -36,6 +40,8 @@ func (f *File) Read(ctx context.Context, req *fuse.ReadRequest, resp *fuse.ReadR
 	end = min(end, int64(len(f.data)))
 	resp.Data = f.data[req.Offset:end]
 
+	f.atime = time.Now()
+
 	return nil
 }
 
@@ -56,6 +62,9 @@ func (f *File) Write(ctx context.Context, req *fuse.WriteRequest, resp *fuse.Wri
 	copy(f.data[req.Offset:], req.Data)
 	resp.Size = len(req.Data)
 
+	f.mtime = time.Now()
+	f.ctime = time.Now() // writing to file constitutes changes in certain fields of inode too
+
 	return nil
 }
 
@@ -66,6 +75,7 @@ func (f *File) Setattr(ctx context.Context, req *fuse.SetattrRequest, resp *fuse
 
 	if req.Valid.Mode() {
 		f.mode = uint32(req.Mode)
+		f.ctime = time.Now() // valid ctime done here
 	}
 
 	if req.Valid.Size() {
@@ -78,9 +88,19 @@ func (f *File) Setattr(ctx context.Context, req *fuse.SetattrRequest, resp *fuse
 		}
 	}
 
+	if req.Valid.Atime() {
+		f.atime = req.Atime
+	}
+	if req.Valid.Mtime() {
+		f.mtime = req.Mtime 
+	}
+
 	resp.Attr.Inode = f.inode
 	resp.Attr.Mode = os.FileMode(f.mode)
 	resp.Attr.Size = uint64(len(f.data))
+	resp.Attr.Atime = f.atime
+	resp.Attr.Mtime = f.mtime
+	resp.Attr.Ctime = f.ctime
 
 	return nil
 }

--- a/internal/fs/file.go
+++ b/internal/fs/file.go
@@ -18,6 +18,8 @@ func (f *File) Attr(ctx context.Context, a *fuse.Attr) error {
 	a.Atime = f.atime
 	a.Mtime = f.mtime
 	a.Ctime = f.ctime
+	a.Uid = f.uid
+	a.Gid = f.gid
 
 	return nil
 }

--- a/internal/fs/file.go
+++ b/internal/fs/file.go
@@ -77,24 +77,27 @@ func (f *File) Setattr(ctx context.Context, req *fuse.SetattrRequest, resp *fuse
 
 	if req.Valid.Mode() {
 		f.mode = uint32(req.Mode)
-		f.ctime = time.Now() // valid ctime done here
+		f.ctime = time.Now()
 	}
 
 	if req.Valid.Size() {
 		if req.Size < uint64(len(f.data)) {
 			f.data = f.data[:req.Size]
+			f.ctime = time.Now() // cuz creating file here
 		} else {
 			newData := make([]byte, req.Size)
 			copy(newData, f.data)
 			f.data = newData
 		}
+		f.mtime = time.Now()
+		f.ctime = time.Now()
 	}
 
 	if req.Valid.Atime() {
 		f.atime = req.Atime
 	}
 	if req.Valid.Mtime() {
-		f.mtime = req.Mtime 
+		f.mtime = req.Mtime
 	}
 
 	resp.Attr.Inode = f.inode
@@ -113,5 +116,5 @@ func (f *File) Flush(ctx context.Context, req *fuse.FlushRequest) error {
 }
 
 func (f *File) Fsync(ctx context.Context, req *fuse.FsyncRequest) error {
-    return nil
+	return nil
 }

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -32,6 +32,9 @@ func (f *FS) Root() (fs.Node, error) {
 			},
 		},
 		fs: f,
+		atime: time.Now(),
+		mtime: time.Now(),
+		ctime: time.Now(),
 	}
 
 	return root, nil
@@ -45,6 +48,8 @@ type File struct {
 	atime time.Time // read
 	mtime time.Time // write | truncate
 	ctime time.Time // metadata (setattr)
+	uid uint32
+	gid uint32
 }
 
 type Dir struct {
@@ -52,4 +57,8 @@ type Dir struct {
 	inode uint64
 	Nodes map[string]fs.Node
 	fs    *FS
+	atime time.Time
+	mtime time.Time
+	ctime time.Time
+
 }

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -31,7 +31,7 @@ func (f *FS) Root() (fs.Node, error) {
 				ctime: time.Now(),
 			},
 		},
-		fs: f,
+		fs:    f,
 		atime: time.Now(),
 		mtime: time.Now(),
 		ctime: time.Now(),
@@ -48,8 +48,8 @@ type File struct {
 	atime time.Time // read
 	mtime time.Time // write | truncate
 	ctime time.Time // metadata (setattr)
-	uid uint32
-	gid uint32
+	uid   uint32
+	gid   uint32
 }
 
 type Dir struct {
@@ -60,5 +60,4 @@ type Dir struct {
 	atime time.Time
 	mtime time.Time
 	ctime time.Time
-
 }

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -3,6 +3,7 @@ package fs
 import (
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"bazil.org/fuse/fs"
 )
@@ -25,6 +26,9 @@ func (f *FS) Root() (fs.Node, error) {
 				inode: nextInode(),
 				data:  []byte("Hello from radFS!\n"),
 				mode:  0o666,
+				atime: time.Now(),
+				mtime: time.Now(),
+				ctime: time.Now(),
 			},
 		},
 		fs: f,
@@ -38,6 +42,9 @@ type File struct {
 	inode uint64
 	data  []byte
 	mode  uint32
+	atime time.Time // read
+	mtime time.Time // write | truncate
+	ctime time.Time // metadata (setattr)
 }
 
 type Dir struct {


### PR DESCRIPTION
# Fix for the issue: updating of attributes (https://github.com/acmpesuecc/radFS/issues/28)

## Context
To add dynamic updation of `ctime`, `mtime` and `atime` attributes. 

## Description
Used the Go time package and added `ctime`, `mtime` and `atime` attributes in the `File` struct in `fs.go` file.
These attributes are updated as needed in our CRUD functions.

### Tests
<img width="776" height="296" alt="image" src="https://github.com/user-attachments/assets/b71bccde-804e-4046-bb91-113df9890de8" />
Works as intended.

## Additional info
In the write function, both the `ctime` and `mtime` attributes are updated as writing to a file also changes inode meta data (such as filesize).
