### PR TITLE
feat(fs): add rename (mv) support for directories

### DIFF
--- a/internal/fs/dir.go
+++ b/internal/fs/dir.go
@@ -127,9 +127,56 @@ func (d *Dir) Remove(ctx context.Context, req *fuse.RemoveRequest) error {
 			return syscall.ENOTEMPTY
 		}
 	}
-	
 
 	delete(d.Nodes, req.Name)
+
+	return nil
+}
+
+func (d *Dir) Rename(ctx context.Context, req *fuse.RenameRequest, newDir fs.Node) error {
+	d.fs.DebugPrint(
+		"RENAME",
+		"from", req.OldName,
+		"to", req.NewName,
+	)
+
+	newParent, ok := newDir.(*Dir)
+	if !ok {
+		return syscall.EINVAL
+	}
+
+	//same name in same dir so do nothing
+	if d == newParent && req.OldName == req.NewName {
+		return nil
+	}
+
+	//safe locking
+	if d == newParent {
+		d.mu.Lock()
+		defer d.mu.Unlock()
+	} else {
+		d.mu.Lock()
+		newParent.mu.Lock()
+		defer d.mu.Unlock()
+		defer newParent.mu.Unlock()
+	}
+
+	//checks if source exists
+	node, exists := d.Nodes[req.OldName]
+	if !exists {
+		return syscall.ENOENT
+	}
+
+	//destination exists so error
+	if _, exists := newParent.Nodes[req.NewName]; exists {
+		return syscall.EEXIST
+	}
+
+	//removes from old
+	delete(d.Nodes, req.OldName)
+
+	//adds to new
+	newParent.Nodes[req.NewName] = node
 
 	return nil
 }

--- a/internal/fs/dir.go
+++ b/internal/fs/dir.go
@@ -167,10 +167,17 @@ func (d *Dir) Rename(ctx context.Context, req *fuse.RenameRequest, newDir fs.Nod
 		return syscall.ENOENT
 	}
 
-	//destination exists so error
-	if _, exists := newParent.Nodes[req.NewName]; exists {
-		return syscall.EEXIST
-	}
+	
+	// if destination exists → overwrite 
+if existing, exists := newParent.Nodes[req.NewName]; exists {
+    // if it's a directory, check if empty
+    if dir, ok := existing.(*Dir); ok {
+        if len(dir.Nodes) > 0 {
+            return syscall.ENOTEMPTY
+        }
+    }
+    delete(newParent.Nodes, req.NewName)
+}
 
 	//removes from old
 	delete(d.Nodes, req.OldName)
@@ -180,3 +187,4 @@ func (d *Dir) Rename(ctx context.Context, req *fuse.RenameRequest, newDir fs.Nod
 
 	return nil
 }
+


### PR DESCRIPTION


## Context
Renaming and moving files between directories

## Description
Implemented the Rename method for directory nodes to support both renaming within the same directory and moving files across different directories according to the Bazil documentation

### Changes
Locates the source node in the current directory
Removes the entry from the source directory
Inserts it into the destination directory with the new name
Handles edge cases

### Test
mv a.txt b.txt
mv dir1/file.txt dir2/file.txt  (moved across directories)
 mv file.txt file.txt   (no changes,no error just shows that its the same file)
Attempt to rename non-existent file returns ENOENT
Attempt to rename to an existing file returns EEXIST


## Additional info
Current implementation uses simple EEXIST